### PR TITLE
Added some tests to help out, plz review & try to get them to pass

### DIFF
--- a/src/test/java/server/InputOutputWrapperTest.java
+++ b/src/test/java/server/InputOutputWrapperTest.java
@@ -1,0 +1,15 @@
+package server;
+
+import java.io.*;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import wrappers.InputOutputWrappers;
+
+public class InputOutputWrapperTest {
+    @Test
+    public void canBeCreated() throws IOException {
+        var actual = new InputOutputWrappers();
+        assertNotNull(actual);
+    }
+}

--- a/src/test/java/server/RequestParseTest.java
+++ b/src/test/java/server/RequestParseTest.java
@@ -8,6 +8,7 @@ import request.RequestBuild;
 import request.RequestParse;
 
 
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,6 +16,24 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class RequestParseTest {
     String testRequest = "GET /simple_get HTTP/1.1\r\nAllow: */*\r\nContent-Length: 5\r\n\r\nhello";
+
+    @Test
+    public void testEmptyRequest() {
+        String testRequest = "";
+        RequestParse parser = new RequestParse(testRequest);
+        assertThrows(ParseException.class, () -> {
+            parser.verb();
+        });
+    }
+
+    @Test
+    public void testBadRequest() {
+        String testRequest = "hello";
+        RequestParse parser = new RequestParse(testRequest);
+        assertThrows(ParseException.class, () -> {
+            parser.verb();
+        });
+    }
 
     @Test
     public void testParseRetrievesVerb() {


### PR DESCRIPTION
- Currently, it's not possible to create an instance of
  `InputOutputWrappers`
- Be sure to always write tests for "bad" outcomes and not just the
  happy path.
- Check things like empty, negative, zero, and other bad inputs.
- I tested that the request parsing throws a `ParseException` feel free
  to use another strategy for signaling a fault condition (could return
  null or something).